### PR TITLE
Add omitempty and struct as map

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -985,15 +985,15 @@ func (d *Decoder) decodeHashViaReflection(by []byte, idx int, ln int, ptr reflec
 				return 0, err
 			}
 
-			var fld int
+			var fld tag
 			var found bool
 
 			if tags == nil {
 				// do nothing
 			} else if fld, found = tags[string(key)]; found {
-				idx, err = d.decodeViaReflection(by, idx, ptr.Field(fld))
+				idx, err = d.decodeViaReflection(by, idx, ptr.Field(fld.id))
 			} else if fld, found = tags[strings.Title(string(key))]; found {
-				idx, err = d.decodeViaReflection(by, idx, ptr.Field(fld))
+				idx, err = d.decodeViaReflection(by, idx, ptr.Field(fld.id))
 			}
 
 			if !found {

--- a/Go/sereal/encode.go
+++ b/Go/sereal/encode.go
@@ -21,6 +21,7 @@ type Encoder struct {
 	DisableDedup         bool       // should we disable deduping of class names and hash keys
 	DisableFREEZE        bool       // should we disable the FREEZE tag, which calls MarshalBinary
 	ExpectedSize         uint       // give a hint to encoder about expected size of encoded data
+	StructAsMap          bool       // convert struct as map
 	version              int        // default version to encode
 	tcache               tagsCache
 }
@@ -553,8 +554,10 @@ func (e *Encoder) encodeStruct(by []byte, st reflect.Value, strTable map[string]
 		}
 	}
 
-	by = append(by, typeOBJECT)
-	by = e.encodeBytes(by, []byte(st.Type().Name()), true, strTable)
+	if !e.StructAsMap {
+		by = append(by, typeOBJECT)
+		by = e.encodeBytes(by, []byte(st.Type().Name()), true, strTable)
+	}
 
 	if e.PerlCompat {
 		// must be a reference

--- a/Go/sereal/encode.go
+++ b/Go/sereal/encode.go
@@ -565,7 +565,7 @@ func (e *Encoder) encodeStruct(by []byte, st reflect.Value, strTable map[string]
 	}
 
 	by = append(by, typeHASH)
-	by = varint(by, uint(len(tags)-fieldToSkip))
+	by = varint(by, uint(len(tags)-fieldsToSkip))
 
 	var err error
 	for f, i := range tags {

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -776,6 +776,16 @@ func TestStructAsMap(t *testing.T) {
 			AOmitTags{},
 			map[string]interface{}{},
 		},
+		{
+			"Half",
+			AOmitTags{Phone: "12345"},
+			map[string]interface{}{"phone": "12345"},
+		},
+		{
+			"Full",
+			AOmitTags{Name: "mr foo", Phone: "12345"},
+			map[string]interface{}{"name": "mr foo", "phone": "12345"},
+		},
 	}
 
 	for _, compat := range []bool{false, true} {
@@ -820,6 +830,9 @@ func TestStructAsMap(t *testing.T) {
 				}
 				if !reflect.DeepEqual(routStruct.Elem().Interface(), routMap.Elem().Interface()) {
 					t.Errorf("roundtrip mismatch for %s: got: %#v expected: %#v\n", v.what, routStruct.Elem().Interface(), routMap.Elem().Interface())
+				}
+				if !reflect.DeepEqual(routStruct.Elem().Interface(), rinputMap.Interface()) {
+					t.Errorf("source mismatch for %s: got: %#v expected: %#v\n", v.what, routStruct.Elem().Interface(), rinputMap.Interface())
 				}
 			})
 		}

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -356,6 +356,11 @@ func TestStructs(t *testing.T) {
 		Phone string `sereal:"phone"`
 	}
 
+	type AOmitTags struct {
+		Name  string `sereal:"name,omitempty"`
+		Phone string `sereal:"phone,omitempty"`
+	}
+
 	type BInt int
 	type AInt struct {
 		B BInt
@@ -444,6 +449,12 @@ func TestStructs(t *testing.T) {
 			AInt{B: BInt(3)},
 			AInt{},
 			AInt{B: BInt(3)},
+		},
+		{
+			"struct with omit field",
+			AOmitTags{Phone: "12345"},
+			AOmitTags{},
+			AOmitTags{Name: "", Phone: "12345"},
 		},
 	}
 
@@ -748,7 +759,72 @@ func TestUnmarshalHeaderError(t *testing.T) {
 		}
 	}
 }
+func TestStructAsMap(t *testing.T) {
+	type AOmitTags struct {
+		Name  string `sereal:"name,omitempty"`
+		Phone string `sereal:"phone,omitempty"`
+	}
 
+	tests := []struct {
+		what        string
+		inputStruct interface{}
+		inputMap    interface{}
+	}{
+
+		{
+			"Empty",
+			AOmitTags{},
+			map[string]interface{}{},
+		},
+	}
+
+	for _, compat := range []bool{false, true} {
+		for _, v := range tests {
+			eMap := Encoder{PerlCompat: compat}
+			eStructAsMap := Encoder{PerlCompat: compat, StructAsMap: true}
+			d := Decoder{}
+
+			var name string
+			if compat {
+				name = "compat_" + v.what
+			} else {
+				name = v.what
+			}
+
+			t.Run(name, func(t *testing.T) {
+				//encode both
+				rinputMap := reflect.ValueOf(v.inputMap)
+				xMap, err := eMap.Marshal(rinputMap.Interface())
+				if err != nil {
+					t.Errorf("error marshalling %s: %s\n", v.what, err)
+					return
+				}
+				rinputStruct := reflect.ValueOf(v.inputStruct)
+				xStruct, err := eStructAsMap.Marshal(rinputStruct.Interface())
+				if err != nil {
+					t.Errorf("error marshalling %s: %s\n", v.what, err)
+					return
+				}
+				//Decode
+				routMap := reflect.New(reflect.TypeOf(v.inputMap))
+				err = d.Unmarshal(xMap, routMap.Interface())
+				if err != nil {
+					t.Errorf("error unmarshalling %s: %s\n", v.what, err)
+					return
+				}
+				routStruct := reflect.New(reflect.TypeOf(v.inputMap)) //Decode like a map
+				err = d.Unmarshal(xStruct, routStruct.Interface())
+				if err != nil {
+					t.Errorf("error unmarshalling %s: %s\n", v.what, err)
+					return
+				}
+				if !reflect.DeepEqual(routStruct.Elem().Interface(), routMap.Elem().Interface()) {
+					t.Errorf("roundtrip mismatch for %s: got: %#v expected: %#v\n", v.what, routStruct.Elem().Interface(), routMap.Elem().Interface())
+				}
+			})
+		}
+	}
+}
 func TestPrepareFreezeRoundtrip(t *testing.T) {
 	_, err := os.Stat("test_freeze")
 	if os.IsNotExist(err) {

--- a/Go/sereal/tags.go
+++ b/Go/sereal/tags.go
@@ -1,0 +1,62 @@
+package sereal
+
+import (
+	"reflect"
+	"strings"
+)
+
+//Based on encoding/json implementation
+
+// tagOptions is the string following a comma in a struct field's "sereal"
+// tag, or the empty string. It does not include the leading comma.
+type tagOptions string
+
+// parseTag splits a struct field's json tag into its name and
+// comma-separated options.
+func parseTag(tag string) (string, tagOptions) {
+	if idx := strings.Index(tag, ","); idx != -1 {
+		return tag[:idx], tagOptions(tag[idx+1:])
+	}
+	return tag, tagOptions("")
+}
+
+// Contains reports whether a comma-separated list of options
+// contains a particular substr flag. substr must be surrounded by a
+// string boundary or commas.
+func (o tagOptions) Contains(optionName string) bool {
+	if len(o) == 0 {
+		return false
+	}
+	s := string(o)
+	for s != "" {
+		var next string
+		i := strings.Index(s, ",")
+		if i >= 0 {
+			s, next = s[:i], s[i+1:]
+		}
+
+		if s == optionName {
+			return true
+		}
+		s = next
+	}
+	return false
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}

--- a/Go/sereal/tagscache.go
+++ b/Go/sereal/tagscache.go
@@ -25,7 +25,7 @@ func (tc *tagsCache) Get(ptr reflect.Value) map[string]tag {
 		return m
 	}
 
-	m := make(map[string]int)
+	m := make(map[string]tag)
 
 	l := ptrType.NumField()
 	for i := 0; i < l; i++ {


### PR DESCRIPTION
Those features are meant to reduce the resulting binary size of Marshal result without impacting Unmarshal compat.

The `omitempty` part is nearly the same as `encoding/json` support.