### PR TITLE
Support pointer to string

### DIFF
--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -787,7 +787,7 @@ func (d *Decoder) decodeViaReflection(by []byte, idx int, ptr reflect.Value) (in
 		if val, idx, err = d.decodeBinary(by, idx+sz, ln, false); err != nil {
 			return 0, err
 		}
-		ptr.SetString(string(val))
+		reflect.Indirect(ptr).SetString(string(val))
 
 	case tag == typeHASH:
 		var ln, sz int

--- a/Go/sereal/decode.go
+++ b/Go/sereal/decode.go
@@ -787,6 +787,10 @@ func (d *Decoder) decodeViaReflection(by []byte, idx int, ptr reflect.Value) (in
 		if val, idx, err = d.decodeBinary(by, idx+sz, ln, false); err != nil {
 			return 0, err
 		}
+		if ptr.Kind() == reflect.Pointer && ptr.IsNil() {
+			ptr.Set(reflect.New(ptr.Type().Elem())) // assign nil pointer
+		}
+
 		reflect.Indirect(ptr).SetString(string(val))
 
 	case tag == typeHASH:

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -463,7 +463,13 @@ func TestStructs(t *testing.T) {
 		{
 			"string pointer",
 			AStringPointer{Pointer: &Afoo.Name},
+			AStringPointer{Pointer: new(string)},
 			AStringPointer{Pointer: &Afoo.Name},
+		},
+		{
+			"string pointer unset",
+			AStringPointer{Pointer: &Afoo.Name},
+			AStringPointer{},
 			AStringPointer{Pointer: &Afoo.Name},
 		},
 	}

--- a/Go/sereal/sereal_test.go
+++ b/Go/sereal/sereal_test.go
@@ -361,6 +361,10 @@ func TestStructs(t *testing.T) {
 		Phone string `sereal:"phone,omitempty"`
 	}
 
+	type AStringPointer struct {
+		Pointer *string `sereal:"pointer,omitempty"`
+	}
+
 	type BInt int
 	type AInt struct {
 		B BInt
@@ -455,6 +459,12 @@ func TestStructs(t *testing.T) {
 			AOmitTags{Phone: "12345"},
 			AOmitTags{},
 			AOmitTags{Name: "", Phone: "12345"},
+		},
+		{
+			"string pointer",
+			AStringPointer{Pointer: &Afoo.Name},
+			AStringPointer{Pointer: &Afoo.Name},
+			AStringPointer{Pointer: &Afoo.Name},
 		},
 	}
 


### PR DESCRIPTION
This add support to logic similar to Go JSON decoder that allocate pointer if needed and set value.

Previously, the decode panic because it try to call SetString on a pointer.